### PR TITLE
Clone cardConfig to resolve object is not extensible errors

### DIFF
--- a/group-card.js
+++ b/group-card.js
@@ -11,7 +11,7 @@ class GroupCard extends HTMLElement {
     if (!cardConfig.card.type) cardConfig.card.type = 'entities';
     const element = document.createElement(`hui-${cardConfig.card.type}-card`);
     this.appendChild(element);
-    this._config = cardConfig;
+    this._config = JSON.parse(JSON.stringify(cardConfig));
   }
 
   set hass(hass) {


### PR DESCRIPTION
Fixes issue #5 by cloning the cardConfig object since it has been marked as non extensible as of Home Assistant 0.106. The recommendations was to make a modification of the setConfig function to deep clone the config object - https://github.com/custom-cards/group-card/issues/5#issue-564993805.

![image](https://user-images.githubusercontent.com/7296474/75504328-247f7f00-59a6-11ea-8c43-b3ced6e84cc6.png)
