### PR TITLE
Allows for customization of the row

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ resources:
 | type | string | **Required** | `custom:group-card`
 | card | object | **Required** | Card object 
 | group | string | **Required** | The entity_id of a group
+| row | object | Optional | The additional parameters to be added to each entity object to customize each row.
 
 Card object
 
@@ -37,6 +38,19 @@ Show all with some exceptions:
     type: entities
     title: Group card
   group: group.bedroom
+```
+
+Use the custom light-entity-row for each entity:
+
+```yaml
+- type: custom:group-card
+  card:
+    type: entities
+    title: Group card
+  group: group.bedroom
+  row:
+    type: custom:light-entity-row
+    showColorPicker: true
 ```
 
 ## Credits

--- a/group-card.js
+++ b/group-card.js
@@ -19,7 +19,20 @@ class GroupCard extends HTMLElement {
     const entities = hass.states[config.group].attributes['entity_id'];
     if (!config.card.entities || config.card.entities.length !== entities.length ||
       !config.card.entities.every((value, index) => value.entity === entities[index].entity)) {
-      config.card.entities = entities;
+      if (!config.row) {
+        config.card.entities = entities;
+      }
+      else {      
+        const fmtentities = [];
+        entities.forEach (function (item) {
+          const stateObj = new Object;
+          for (var k in config.row)
+            stateObj[k]=config.row[k];
+          stateObj.entity = item;
+          fmtentities.push (stateObj);
+        });
+        config.card.entities = fmtentities;
+      }
     }
     this.lastChild.setConfig(config.card);
     this.lastChild.hass = hass;


### PR DESCRIPTION
Allows the addition of custom row configuration which will be applied to all entities in the group. This, for example, allows all lights in a group to be displayed using light-entity-row, or another per-entity modifier.
